### PR TITLE
Add new connection error message for mysql PDO

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -57,6 +57,7 @@ trait DetectsLostConnections
             'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.',
             'SQLSTATE[08006] [7] could not translate host name',
             'TCP Provider: Error code 0x274C',
+            'SQLSTATE[HY000] [2002] No such file or directory',
         ]);
     }
 }


### PR DESCRIPTION
Got this error message when mySQL connection to SQL Proxy in Google Cloud was not available:
```
SQLSTATE[HY000] [2002] No such file or directory (SQL: xxxx )
```
Following database config is used:
```
$database=[
    'default' => env('DB_CONNECTION', 'mysql'),
    'connections' => [
        'mysql' => [
            'driver' => 'mysql',
            'url' => env('DATABASE_URL'),
            'host' => 'p:localhost',
            'unix_socket' => '/cloudsql/<project>:<region>:<instance_name>',
            'port' => env('DB_PORT', '3306'),
            'database' => env('DB_DATABASE'),
            'username' => env('DB_USERNAME'),
            'password' => env('DB_PASSWORD'),
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
            'prefix' => '',
            'prefix_indexes' => true,
            'strict' => false,
            'engine' => null,
            'options' => extension_loaded('pdo_mysql') ? array_filter([
                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
                PDO::ATTR_TIMEOUT => 5,
            ]) : [],
        ],
    ],
    'migrations' => 'migrations',
];
```
I am already using this in production and know this works. I provoked this error to test error handling when connection is lost. I am checking against this trait in my error handler.